### PR TITLE
separating team table row generation from sponsor list

### DIFF
--- a/ui/js/scoresfunctions.js
+++ b/ui/js/scoresfunctions.js
@@ -140,6 +140,9 @@ function getHighScores() {
 function getTeamRanks() {
     "use strict";
     $("#rankUpdateContainer").html("Loading ranking data...");
+    if (localStorage.offseason == "true") {
+        $('#rankUpdateContainer').html("Offline Event");
+    }
     $('#ranksProgressBar').show();
     $('#teamRanksPicker').addClass('alert-danger');
     var team = {};

--- a/ui/js/teamupdates.js
+++ b/ui/js/teamupdates.js
@@ -47,8 +47,8 @@ function getTeamUpdates(teamNumber, singleton) {
                         title: 'OK',
                         action: function (dialogRef) {
                             dialogRef.close();
-                            updateTeamTable();
                             updateTeamInfo(teamNumber);
+                            updateTeamTable();
                         }
                     }]
                 });


### PR DESCRIPTION
In prior versions, we had combined the process for breaking out the sponsors and org name from the combined value that FIRST provides, with the process for generating a row for the Teams Table. We have now separated those actions, which will make it easier to move to React for the UI.