### PR TITLE
Reduced Alliance events

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -140,6 +140,7 @@
                 <p><b>Event Location:</b> <span id="eventLocationContainer">no event selected</span></p>
                 <p><b>Event Dates:</b> <span id="eventDateContainer">no event selected</span></p>
                 <p><b>Number of Competing Teams:</b> <span id="eventTeamCount">no event selected</span></p>
+                <p><b>Number of Playoff Alliances:</b> <span id="eventAllianceCount">no event selected</span></p>
                 <p><b>Last Event List update:</b> <span id="eventUpdateContainer">no event selected</span></p>
                 <p><b>Last Team Info update:</b> <span id="teamUpdateContainer">no event selected</span></p>
                 <div id="teamloadprogress" class="progress">
@@ -1032,42 +1033,42 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam1">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam1">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam2">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam2">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam3">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam3">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam4">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam4">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam5">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam5">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam6">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam6">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam7">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam7">List of teams</div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <div class="allianceTeam" id="backupAllianceTeam8">List of teams</div>
+                                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam8">List of teams</div>
                                     </td>
                                 </tr>
                             </table>
@@ -1135,6 +1136,7 @@
                     </tr>
                 </table>
             </div>
+            <p class="showAlliancePlayoff" id="showPlayoffBracket"><strong><span onclick="showAllianceSelectionPlayoff('playoff');">Tap here to show Playoff Bracket.</span></strong></p>
         </div>
         <div id="awards" class="tabcontent container-fluid">
             <div id="awardsInfo" class="allianceAnnounce">

--- a/ui/js/scoresfunctions.js
+++ b/ui/js/scoresfunctions.js
@@ -236,19 +236,31 @@ function getTeamRanks() {
                 $("#Alliance1Captain").html("Alliance 1 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance1Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='chosenAllianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
                 allianceChoices.Alliance2Captain = allianceTeamList[0];
                 $("#Alliance2Captain").html("Alliance 2 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance2Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance3Captain = allianceTeamList[0];
-                $("#Alliance3Captain").html("Alliance 3 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance3Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance4Captain = allianceTeamList[0];
-                $("#Alliance4Captain").html("Alliance 4 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance4Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance5Captain = allianceTeamList[0];
-                $("#Alliance5Captain").html("Alliance 5 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance5Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance6Captain = allianceTeamList[0];
-                $("#Alliance6Captain").html("Alliance 6 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance6Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance7Captain = allianceTeamList[0];
-                $("#Alliance7Captain").html("Alliance 7 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance7Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-                allianceChoices.Alliance8Captain = allianceTeamList[0];
-                $("#Alliance8Captain").html("Alliance 8 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance8Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
-
+                if (allianceCount > 2) {
+                    allianceChoices.Alliance3Captain = allianceTeamList[0];
+                    $("#Alliance3Captain").html("Alliance 3 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance3Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                if (allianceCount > 3) {
+                    allianceChoices.Alliance4Captain = allianceTeamList[0];
+                    $("#Alliance4Captain").html("Alliance 4 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance4Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                if (allianceCount > 4) {
+                    allianceChoices.Alliance5Captain = allianceTeamList[0];
+                    $("#Alliance5Captain").html("Alliance 5 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance5Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                if (allianceCount > 5) {
+                    allianceChoices.Alliance6Captain = allianceTeamList[0];
+                    $("#Alliance6Captain").html("Alliance 6 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance6Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                if (allianceCount > 6) {
+                    allianceChoices.Alliance7Captain = allianceTeamList[0];
+                    $("#Alliance7Captain").html("Alliance 7 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance7Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                if (allianceCount > 7) {
+                    allianceChoices.Alliance8Captain = allianceTeamList[0];
+                    $("#Alliance8Captain").html("Alliance 8 Captain<div class ='allianceTeam allianceCaptain' captain='Alliance8Captain' teamnumber = '" + allianceTeamList[0] + "' id='allianceTeam" + allianceTeamList[0] + "' onclick='allianceAlert(this)'>" + allianceTeamList.shift() + "</div>");
+                }
+                $("#backupMessage").html(`(Initially rank ${allianceCount+1} to ${allianceCount+8} top to bottom)`)
                 $("#backupAllianceTeam1").html("<div id='backupAllianceTeamContainer1' class ='allianceTeam' captain='alliance' teamnumber=" + allianceTeamList[0] + " onclick='allianceAlert(this)'>" + allianceTeamList[0] + "</div>");
                 $("#backupAllianceTeam2").html("<div id='backupAllianceTeamContainer2' class ='allianceTeam' captain='alliance' teamnumber=" + allianceTeamList[1] + " onclick='allianceAlert(this)'>" + allianceTeamList[1] + "</div>");
                 $("#backupAllianceTeam3").html("<div id='backupAllianceTeamContainer3' class ='allianceTeam' captain='alliance' teamnumber=" + allianceTeamList[2] + " onclick='allianceAlert(this)'>" + allianceTeamList[2] + "</div>");
@@ -258,16 +270,17 @@ function getTeamRanks() {
                 $("#backupAllianceTeam7").html("<div id='backupAllianceTeamContainer7' class ='allianceTeam' captain='alliance' teamnumber=" + allianceTeamList[6] + " onclick='allianceAlert(this)'>" + allianceTeamList[6] + "</div>");
                 $("#backupAllianceTeam8").html("<div id='backupAllianceTeamContainer8' class ='allianceTeam' captain='alliance' teamnumber=" + allianceTeamList[7] + " onclick='allianceAlert(this)'>" + allianceTeamList[7] + "</div>");
 
+
                 allianceTeamList = sortAllianceTeams(allianceTeamList);
 
-                $("#rankUpdateContainer").html(moment().format("dddd, MMMM Do YYYY, "+timeFormats[localStorage.timeFormat]));
+                $("#rankUpdateContainer").html(moment().format("dddd, MMMM Do YYYY, " + timeFormats[localStorage.timeFormat]));
             }
             $(".districtRank").hide();
             if (localStorage.eventDistrict != "") {
                 $(".districtRank").show();
                 getDistrictRanks(localStorage.eventDistrict, localStorage.currentYear);
             }
-            backupAllianceList = allianceListUnsorted.slice(8);
+            backupAllianceList = allianceListUnsorted.slice(allianceCount);
         }
     });
     if (localStorage.offseason !== "true") {

--- a/ui/js/scripts.js
+++ b/ui/js/scripts.js
@@ -644,7 +644,150 @@ function prepareAllianceSelection() {
     rankingsList = [];
     districtRankings = {};
     currentAllianceChoice = 0;
-    $("#allianceSelectionTable").html('<table> <tr> <td><table class="availableTeams"> <tr> <td colspan="5"><strong>Teams for Alliance Selection</strong></td></tr><tr> <td id="allianceTeamList1" class="col1"><div class="allianceTeam">List of teams</div></td><td id="allianceTeamList2" class="col1"><div class="allianceTeam">List of teams</div></td><td id="allianceTeamList3" class="col1"><div class="allianceTeam">List of teams</div></td><td id="allianceTeamList4" class="col1"><div class="allianceTeam">List of teams</div></td><td id="allianceTeamList5" class="col1"><div class="allianceTeam allianceCaptain">List of teams</div></td></tr></table></td><td class="col1"><table id="backupTeamsTable" class="backupAlliancesTable"> <tr> <td><p><strong>Backup Alliances</strong><br>(Initially rank 9 to 16 top to bottom)</p></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam1">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam2">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam3">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam4">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam5">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam6">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam7">List of teams</div></td></tr><tr> <td><div class="allianceTeam" id="backupAllianceTeam8">List of teams</div></td></tr></table></td><td><table class="alliancesTeamsTable"> <tr class="col6"> <td id="Alliance1" class="col3 dropzone"><div class="alliancedrop" id="Alliance1Captain">Alliance 1 Captain</div><div class="alliancedrop nextAllianceChoice" id="Alliance1Round1" >Alliance 1 first choice</div><div class="alliancedrop" id="Alliance1Round2" >Alliance 1 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance1Round3" >Alliance 1 third choice</div></td><td id="Alliance8" class="col3"><div class="alliancedrop" id="Alliance8Captain" >Alliance 8 Captain</div><div class="alliancedrop" id="Alliance8Round1" >Alliance 8 first choice</div><div class="alliancedrop" id="Alliance8Round2" >Alliance 8 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance8Round3" >Alliance 8 third choice</div></td></tr><tr class="col6"> <td id="Alliance2" class="col3"><div class="alliancedrop" id="Alliance2Captain" >Alliance 2 Captain</div><div class="alliancedrop" id="Alliance2Round1" >Alliance 2 first choice</div><div class="alliancedrop" id="Alliance2Round2" >Alliance 2 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance2Round3" >Alliance 2 third choice</div></td><td id="Alliance7" class="col3"><div class="alliancedrop" id="Alliance7Captain" >Alliance 7 Captain</div><div class="alliancedrop" id="Alliance7Round1" >Alliance 7 first choice</div><div class="alliancedrop" id="Alliance7Round2" >Alliance 7 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance7Round3" >Alliance 7 third choice</div></td></tr><tr class="col6"> <td id="Alliance3" class="col3"><div class="alliancedrop" id="Alliance3Captain" >Alliance 3 Captain</div><div class="alliancedrop" id="Alliance3Round1" >Alliance 3 first choice</div><div class="alliancedrop" id="Alliance3Round2" >Alliance 3 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance3Round3" >Alliance 3 third choice</div></td><td id="Alliance6" class="col3"><div class="alliancedrop" id="Alliance6Captain" >Alliance 6 Captain</div><div class="alliancedrop" id="Alliance6Round1" >Alliance 6 first choice</div><div class="alliancedrop" id="Alliance6Round2" >Alliance 6 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance6Round3" >Alliance 6 third choice</div></td></tr><tr class="col6"> <td id="Alliance4" class="col3"><div class="alliancedrop" id="Alliance4Captain" >Alliance 4 Captain</div><div class="alliancedrop" id="Alliance4Round1" >Alliance 4 first choice</div><div class="alliancedrop" id="Alliance4Round2" >Alliance 4 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance4Round3" >Alliance 4 third choice</div></td><td id="Alliance5" class="col3"><div class="alliancedrop" id="Alliance5Captain" >Alliance 5 Captain</div><div class="alliancedrop" id="Alliance5Round1" >Alliance 5 first choice</div><div class="alliancedrop" id="Alliance5Round2" >Alliance 5 second choice</div><div class="alliancedrop thirdAllianceSelection" id="Alliance5Round3" >Alliance 5 third choice</div></td></tr></table></td></tr></table><p class="showAlliancePlayoff" id="showPlayoffBracket"><strong><span onclick="showAllianceSelectionPlayoff(\'playoff\');">Tap here to show Playoff Bracket.</span></strong></p>');
+    allianceSelectionOrder = [];
+    for (var alliance of allianceSelectionOrderBase) {
+        if (parseInt(alliance.substring(8, 9)) <= allianceCount) {
+            allianceSelectionOrder.push(alliance)
+        }
+    };
+
+    $("#allianceSelectionTable").html(`<table>
+    <tr>
+        <td>
+            <table class="availableTeams">
+                <tr>
+                    <td colspan="5"><strong>Teams for Alliance Selection</strong></td>
+                </tr>
+                <tr>
+                    <td id="allianceTeamList1" class="col1">
+                        <div class="allianceTeam">List of teams</div>
+                    </td>
+                    <td id="allianceTeamList2" class="col1">
+                        <div class="allianceTeam">List of teams</div>
+                    </td>
+                    <td id="allianceTeamList3" class="col1">
+                        <div class="allianceTeam">List of teams</div>
+                    </td>
+                    <td id="allianceTeamList4" class="col1">
+                        <div class="allianceTeam">List of teams</div>
+                    </td>
+                    <td id="allianceTeamList5" class="col1">
+                        <div class="allianceTeam allianceCaptain">List of teams</div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <td class="col1">
+            <table id="backupTeamsTable" class="backupAlliancesTable">
+                <tr>
+                    <td>
+                        <p><strong>Backup Alliances</strong></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam1">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam2">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam3">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam4">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam5">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam6">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam7">List of teams</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="allianceTeam backupAlliance" id="backupAllianceTeam8">List of teams</div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <td>
+            <table class="alliancesTeamsTable">
+                <tr class="col6">
+                    <td id="Alliance1" class="col3 dropzone">
+                        <div class="alliancedrop" id="Alliance1Captain">Alliance 1 Captain</div>
+                        <div class="alliancedrop nextAllianceChoice" id="Alliance1Round1">Alliance 1 first choice</div>
+                        <div class="alliancedrop" id="Alliance1Round2">Alliance 1 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance1Round3">Alliance 1 third choice</div>
+                    </td>
+                    <td id="Alliance8" class="col3">
+                        <div class="alliancedrop" id="Alliance8Captain">Alliance 8 Captain</div>
+                        <div class="alliancedrop" id="Alliance8Round1">Alliance 8 first choice</div>
+                        <div class="alliancedrop" id="Alliance8Round2">Alliance 8 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance8Round3">Alliance 8 third choice</div>
+                    </td>
+                </tr>
+                <tr class="col6">
+                    <td id="Alliance2" class="col3">
+                        <div class="alliancedrop" id="Alliance2Captain">Alliance 2 Captain</div>
+                        <div class="alliancedrop" id="Alliance2Round1">Alliance 2 first choice</div>
+                        <div class="alliancedrop" id="Alliance2Round2">Alliance 2 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance2Round3">Alliance 2 third choice</div>
+                    </td>
+                    <td id="Alliance7" class="col3">
+                        <div class="alliancedrop" id="Alliance7Captain">Alliance 7 Captain</div>
+                        <div class="alliancedrop" id="Alliance7Round1">Alliance 7 first choice</div>
+                        <div class="alliancedrop" id="Alliance7Round2">Alliance 7 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance7Round3">Alliance 7 third choice</div>
+                    </td>
+                </tr>
+                <tr class="col6">
+                    <td id="Alliance3" class="col3">
+                        <div class="alliancedrop" id="Alliance3Captain">Alliance 3 Captain</div>
+                        <div class="alliancedrop" id="Alliance3Round1">Alliance 3 first choice</div>
+                        <div class="alliancedrop" id="Alliance3Round2">Alliance 3 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance3Round3">Alliance 3 third choice</div>
+                    </td>
+                    <td id="Alliance6" class="col3">
+                        <div class="alliancedrop" id="Alliance6Captain">Alliance 6 Captain</div>
+                        <div class="alliancedrop" id="Alliance6Round1">Alliance 6 first choice</div>
+                        <div class="alliancedrop" id="Alliance6Round2">Alliance 6 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance6Round3">Alliance 6 third choice</div>
+                    </td>
+                </tr>
+                <tr class="col6">
+                    <td id="Alliance4" class="col3">
+                        <div class="alliancedrop" id="Alliance4Captain">Alliance 4 Captain</div>
+                        <div class="alliancedrop" id="Alliance4Round1">Alliance 4 first choice</div>
+                        <div class="alliancedrop" id="Alliance4Round2">Alliance 4 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance4Round3">Alliance 4 third choice</div>
+                    </td>
+                    <td id="Alliance5" class="col3">
+                        <div class="alliancedrop" id="Alliance5Captain">Alliance 5 Captain</div>
+                        <div class="alliancedrop" id="Alliance5Round1">Alliance 5 first choice</div>
+                        <div class="alliancedrop" id="Alliance5Round2">Alliance 5 second choice</div>
+                        <div class="alliancedrop thirdAllianceSelection" id="Alliance5Round3">Alliance 5 third choice</div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>`);
     $("#showPlayoffBracket").hide();
 }
 
@@ -1408,10 +1551,16 @@ function getTeamList(year) {
                 teamCountTotal = data.teamCountTotal;
                 localStorage.teamList = "[]"
             } else {
-
                 $("#eventTeamCount").html(data.teamCountTotal);
                 teamCountTotal = data.teamCountTotal;
-                $('#teamsTableEventName').html(localStorage.eventName)
+                if (teamCountTotal <= 24) {
+                    allianceCount = Math.floor((teamCountTotal - 1) / 3);
+                    allianceSelectionLength = 2 * allianceCount - 1;
+                } else {
+                    allianceCount = 8;
+                }
+                $('#eventAllianceCount').html(allianceCount);
+                $('#teamsTableEventName').html(localStorage.eventName);
 
                 for (var i = 0; i < data.teams.length; i++) {
                     var element = data.teams[i];
@@ -2215,7 +2364,7 @@ function displayAwardsTeams(teamList) {
 function displayAllianceCaptains(startingPosition) {
     "use strict";
 
-    for (var i = 1; i <= 8; i++) {
+    for (var i = 1; i <= allianceCount; i++) {
         if (i <= startingPosition + 1) {
             $("#Alliance" + i + "Captain").html("Alliance " + i + " Captain<div class ='allianceTeam allianceCaptain' captain='Alliance" + i + "Captain' teamnumber='" + allianceChoices["Alliance" + i + "Captain"] + "' id='allianceTeam" + allianceChoices["Alliance" + i + "Captain"] + "' onclick='chosenAllianceAlert(this)'>" + allianceChoices["Alliance" + i + "Captain"] + "</div>")
         } else {
@@ -2225,6 +2374,7 @@ function displayAllianceCaptains(startingPosition) {
 }
 
 function displayBackupAlliances(reason) {
+    $(".backupAlliance").hide();
     for (var i = 0; i < declinedList.length; i++) {
         if (backupAllianceList.indexOf(Number(declinedList[i])) >= 0) {
             backupAllianceList.splice(backupAllianceList.indexOf(Number(declinedList[i])), 1);
@@ -2234,6 +2384,7 @@ function displayBackupAlliances(reason) {
     for (var i = 1; i <= 8; i++) {
         if (i <= backupAllianceList.length) {
             $("#backupAllianceTeam" + i).html("<div id='backupAllianceTeamContainer" + i + "' class ='allianceTeam' captain='alliance' teamnumber=" + backupAllianceList[i - 1] + " onclick='allianceAlert(this)'>" + backupAllianceList[i - 1] + "</div>");
+            $("#backupAllianceTeam" + i).show();
         }
 
     }
@@ -2426,22 +2577,21 @@ function allianceAlert(teamContainer) {
                                     teamContainer.setAttribute("captain", "alliance");
                                     var nextAlliance = parseInt(allianceBackfill.substr(8, 1));
 
-                                    for (var j = nextAlliance; j < 8; j++) {
+                                    for (var j = nextAlliance; j < allianceCount; j++) {
                                         allianceChoices["Alliance" + j + "Captain"] = Number(allianceChoices["Alliance" + (j + 1) + "Captain"])
                                     }
                                     //test for declined team
-                                    //allianceChoices.Alliance8Captain = allianceListUnsorted[7];
-                                    allianceChoices.Alliance8Captain = backupAllianceList[0];
+                                    allianceChoices[`Alliance${allianceCount}Captain`] = backupAllianceList[0];
 
-                                    index = allianceTeamList.indexOf(parseInt(allianceChoices.Alliance8Captain));
+                                    index = allianceTeamList.indexOf(parseInt(allianceChoices[`Alliance${allianceCount}Captain`]));
                                     if (index > -1) {
                                         allianceTeamList.splice(index, 1)
                                     }
-                                    index = backupAllianceList.indexOf(parseInt(allianceChoices.Alliance8Captain));
+                                    index = backupAllianceList.indexOf(parseInt(allianceChoices[`Alliance${allianceCount}Captain`]));
                                     if (index > -1) {
                                         backupAllianceList.splice(index, 1)
                                     }
-                                    index = allianceListUnsorted.indexOf(parseInt(allianceChoices.Alliance8Captain));
+                                    index = allianceListUnsorted.indexOf(parseInt(allianceChoices[`Alliance${allianceCount}Captain`]));
                                     if (index > -1) {
                                         allianceListUnsorted.splice(index, 1)
                                     }
@@ -2451,7 +2601,7 @@ function allianceAlert(teamContainer) {
                                 teamContainer.id = "allianceTeam" + teamContainer.getAttribute("teamNumber");
                                 $("#" + teamContainer.getAttribute("id")).removeClass("allianceCaptain");
                                 $("#" + allianceSelectionOrder[currentAllianceChoice]).append(teamContainer);
-                                $("#" + allianceSelectionOrder[currentAllianceChoice].substr(0, 9)).removeClass("dropzone");
+                                $("#" + allianceSelectionOrder[currentAllianceChoice].substring(0, 9)).removeClass("dropzone");
                                 $("#" + allianceSelectionOrder[currentAllianceChoice]).removeClass("nextAllianceChoice");
                                 currentAllianceChoice++;
                                 if (currentAllianceChoice <= allianceSelectionLength) {
@@ -3208,9 +3358,9 @@ function fixSponsors(teamData) {
 
 function teamTableRankHighlight(rank) {
     "use strict";
-    if ((rank <= 8) && (rank > 1)) {
+    if ((rank <= allianceCount) && (rank > 1)) {
         return "rank2"
-    } else if ((rank < 11) && (rank > 8)) {
+    } else if ((rank < (allianceCount + 3)) && (rank > allianceCount)) {
         return "rank9"
     } else if (rank === 1) {
         return "rank1"
@@ -3221,10 +3371,10 @@ function teamTableRankHighlight(rank) {
 
 function rankHighlight(station, rank) {
     "use strict";
-    if ((rank <= 8) && (rank > 1)) {
+    if ((rank <= allianceCount) && (rank > 1)) {
         document.getElementById(station).style.color = "white";
         document.getElementById(station).style.backgroundColor = "green"
-    } else if ((rank < 11) && (rank > 8)) {
+    } else if ((rank < (allianceCount + 3)) && (rank > allianceCount)) {
         document.getElementById(station).style.color = "black";
         document.getElementById(station).style.backgroundColor = "yellow"
     } else if (rank === 1) {
@@ -4080,11 +4230,13 @@ function showAllianceSelectionPlayoff(targetMode) {
         $("#allianceInfo").hide();
         $("#allianceSelectionTable").hide();
         $("#showPlayoffBracket").hide();
+        $("#showAllianceSelection").show();
     } else {
         $("#playoffBracket").hide();
         $("#allianceInfo").show();
         $("#allianceSelectionTable").show();
         $("#showPlayoffBracket").show();
+        $("#showAllianceSelection").hide();
     }
 }
 

--- a/ui/js/staticvariables.js
+++ b/ui/js/staticvariables.js
@@ -16,12 +16,15 @@ var declinedListUndo = [];
 var backupAllianceListUndo = [];
 var undoCounter=[];
 var allianceSelectionLength = 15;
+var allianceCount = 8;
 var rankingsList = [];
 var districtRankings = {};
 var eventTeamList = [];
 var eventQualsSchedule = [];
 var eventPlayoffSchedule = [];
-var allianceSelectionOrder = ["Alliance1Round1", "Alliance2Round1", "Alliance3Round1", "Alliance4Round1", "Alliance5Round1", "Alliance6Round1", "Alliance7Round1", "Alliance8Round1", "Alliance8Round2", "Alliance7Round2", "Alliance6Round2", "Alliance5Round2", "Alliance4Round2", "Alliance3Round2", "Alliance2Round2", "Alliance1Round2", "Alliance1Round3", "Alliance2Round3", "Alliance3Round3", "Alliance4Round3", "Alliance5Round3", "Alliance6Round3", "Alliance7Round3", "Alliance8Round3"];
+var allianceSelectionOrderBase = ["Alliance1Round1", "Alliance2Round1", "Alliance3Round1", "Alliance4Round1", "Alliance5Round1", "Alliance6Round1", "Alliance7Round1", "Alliance8Round1", "Alliance8Round2", "Alliance7Round2", "Alliance6Round2", "Alliance5Round2", "Alliance4Round2", "Alliance3Round2", "Alliance2Round2", "Alliance1Round2", "Alliance1Round3", "Alliance2Round3", "Alliance3Round3", "Alliance4Round3", "Alliance5Round3", "Alliance6Round3", "Alliance7Round3", "Alliance8Round3"];
+var allianceSelectionOrder = [];
+
 var currentAllianceChoice = 0;
 var allianceChoices = {};
 var replacementAlliance = {};
@@ -71,7 +74,7 @@ playoffTieBreakerMatches["24"] = ["19","20","21","22","23"];
 playoffTieBreakerMatches["list"] = ["9","10","11","12","17","18","24"];
 var tbaBatchDelay = 50;
 
-for (var i = 1; i < 9; i++) {
+for (var i = 1; i <= allianceCount; i++) {
     allianceChoices['Alliance' + i + 'Captain'] = "";
 }
 for (var i = 0; i < allianceSelectionOrder.length; i++) {
@@ -6667,3 +6670,5 @@ var timeFormats = {
     "12hrNoSec":"h:mm a",
     "24hrNoSec":"HH:mm"
 }
+
+var dummyTeams = ["9999","9998","9997","9996","9995","9994","9993","9992","9991","9990","9989","9988","9987","9986","9985","9984","9983","9982","9981","9980","9979"]


### PR DESCRIPTION
We have added in support for small events. These have a reduced team count, and therefore fewer than 8 Playoff Alliances.
This commit includes the logic to determine how many Playoff Alliances should be selected, and the routines to support the reduction in Playoff Alliances. It reports this number on the setup screen once an event loads.
Fixes #42